### PR TITLE
payroll corrected

### DIFF
--- a/a3_finance/overrides/salary_slip.py
+++ b/a3_finance/overrides/salary_slip.py
@@ -788,6 +788,7 @@ def update_tax_on_salary_slip(slip, method):
             "salary_component": "Income Tax",
             "amount": tax_amount
         })
+    slip.calculate_net_pay()
 
 
     # if deduction_row != slip.custom_income_tax:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that net pay on the salary slip is recalculated immediately after updating the income tax deduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->