### PR TITLE
setting updated

### DIFF
--- a/a3_finance/a3_finance/doctype/payroll_master_setting/payroll_master_setting.json
+++ b/a3_finance/a3_finance/doctype/payroll_master_setting/payroll_master_setting.json
@@ -374,7 +374,7 @@
    "fieldname": "effective_from",
    "fieldtype": "Date",
    "label": "Effective From",
-   "reqd": 1
+   "reqd": 0
   },
   {
    "fieldname": "column_break_gxvj",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The "effective_from" field in Payroll Master Setting is now optional instead of required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->