### PR TITLE
payroll updates

### DIFF
--- a/a3_finance/overrides/salary_slip.py
+++ b/a3_finance/overrides/salary_slip.py
@@ -1440,9 +1440,8 @@ def set_custom_payroll_days_for_suspended(slip, method=None):
                             excluding suspension-overlap days.
     If suspension covers the entire 30-day window => result is 0.
     """
-    if slip.custom_employee_status in [ "Suspended","Active"]:
-        emp = frappe.get_doc("Employee", slip.employee)
-        
+    emp = frappe.get_doc("Employee", slip.employee)
+    if emp.custom_payroll_effected_from:
         # Fixed payroll window (monthly)
         p_start = getdate(slip.start_date)
         p_end = get_last_day(p_start)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payroll days calculation for suspended or active employees now runs only when an effective payroll start date is set on the employee, ensuring the 30-day window is applied appropriately.
  * Users may observe adjusted worked days, holidays, and related amounts on salary slips for affected employees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->