### PR TITLE
Reactivate Additional Salaries PLI AND LIC

### DIFF
--- a/a3_finance/hooks.py
+++ b/a3_finance/hooks.py
@@ -170,8 +170,15 @@ scheduler_events = {
         # "a3_finance.overrides.employee_updates.update_years_of_service_for_all_employees",
         "a3_finance.overrides.account_validity.update_account_status",
         "a3_finance.scheduler.update_employee_total_service.update_total_service_for_all_employees"
-    ]
+    ],
+    "cron": {
+        "0 0 15 * *": [  # Run at midnight on 15th
+            "a3_finance.overrides.additional_salary.reactivate_disabled_add_salaries"
+        ]
+    }
 }
+
+
 
 
 # Document Events


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an automated monthly background task that reactivates eligible recurring salary components (PLI Recovery, LIC Recovery) on the 15th, ensuring deductions resume without manual intervention.
  - Adds activity logging for better traceability of reactivations.

- Chores
  - Updated scheduling configuration to include the new monthly background job alongside existing daily tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->